### PR TITLE
switch from SORT_STRING to SORT_NATURAL line 14

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,8 +10,8 @@ $client = new GuzzleHttp\Client();
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+//Sort the episodes- switch from SORT_STRING to SORT_NATURAL to list eps in order
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This PR changes the way the array of episodes is sorted before the data is rendered by switching from SORT_STRING to SORT_NATURAL, thereby it lists the episodes in order of series/episode number
---

**Testing**


In a browser  verify that the episodes are listed by series/episode number

---

**Deployment steps**

Merge branch `issue1` into `master`

Compile assets: `./bin/node_modules/gulp`
