### PR TITLE
redirect to 404.html

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,11 +7,19 @@ $twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
 $client = new GuzzleHttp\Client();
+
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+if($res->getStatusCode() == 404){
+//if response fails (not 200) send a clean response message
+echo $twig->render('404.html');
+}else{
+
 $data = json_decode($res->getBody(), true);
+
 
 //Sort the episodes
 array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);
+};

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bobby's Favourite Simpson's Epsiodes</title>
+    <link href="/resources/compiled/css/main.css" rel="stylesheet">
+    <head>
+<body>
+    <div class="row">   
+        <h3 class="text-danger">Sorry, there was an error. Please try again by reloading the page.</h3>
+    </div>
+<script type="text/javascript" src="/resources/compiled/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a 404 page in the templates folder to redirect to if the api fails to load.  Redirection takes place in index.php file by a an if/else statement

---

**Testing**

Tell us how we should test your work. What steps do we need to take. What has changed. e.g.

rename the api string in index.php to an invalid string to create an error and test the redirect works 

---

**Deployment steps**



Merge branch `issue2` into `master`

Compile assets: `./bin/node_modules/gulp`
