### PR TITLE
Changed h4 scss settings

### DIFF
--- a/public/resources/sass/base/_typography.scss
+++ b/public/resources/sass/base/_typography.scss
@@ -4,8 +4,8 @@
 
 h4 {
     color: $gray-dark;
-
-    small {
-        color: $gray-light;
-    }
+    font-weight: bold;
+    // small {
+    //     color: $gray-dark;
+    // }
 }


### PR DESCRIPTION
This PR added CSS stylings for h4 to _typography.css file, added font-weight: bold and removed stylings for small text to make it more legible 

---

**Testing**

In a browser verify that episode title text is bold and series/episode numbers are legible 

---

**Deployment steps**


Merge branch `issue3` into `master`

Compile assets: `./bin/node_modules/gulp`
