### PR TITLE
remove existing tool-tip

### DIFF
--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -17,5 +17,7 @@ module.exports = function () {
     
     // Initialise Bootstrap tooltips
     //http://getbootstrap.com/javascript/#tooltips
+    //attempt to remove existing tooltip
+    $('[data-toggle="tooltip"]').tooltip('destroy')
     $('[data-toggle="tooltip"]').tooltip()
 }


### PR DESCRIPTION
Tell us what you did e.g.

This PR adds $('[data-toggle="tooltip"]').tooltip('destroy') as per bootstrap documentation to popover.js so tooltips close upon opening a new one

---

**Testing**



In a browser verify that tooltips close upon opening a new one by clicking on the image for each episode

---

**Deployment steps**


Merge branch `issue4` into `master`

Compile assets: `./bin/node_modules/gulp`
