### PR TITLE
notes added to file for cache file strategy

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,8 +7,16 @@ $twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
 $client = new GuzzleHttp\Client();
+//if cache file exists $res = cacheFile
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+if($res->getStatusCode() == 404){
+//if response fails (not 200) send a clean response message
+echo $twig->render('404.html');
+}
+else{
+// if !cache then create cachefile for future use
 $data = json_decode($res->getBody(), true);
+
 
 //Sort the episodes
 array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);


### PR DESCRIPTION
Commented on steps to take to cache request data so the api is not called each time data is requested by the client

---

**Testing**

work is incomplete, however once completed, a viable test would be to load the page once disconnect the test machine from the network and reload the page via ctrl-f5

---

**Deployment steps**
Work is incomplete so changes are negligible

Merge branch `Change1` into `master`

Compile assets: `./bin/node_modules/gulp`
